### PR TITLE
feat: add LiteLLM as unified LLM provider gateway

### DIFF
--- a/plugins/services/service_llm.py
+++ b/plugins/services/service_llm.py
@@ -554,6 +554,12 @@ class LiteLLMLLM(BaseLLM):
         except Exception as e:
             message = extract_llm_error_text(e)
             logger.error(f"LiteLLM Invoke Error: {message}")
+            # Check for rate limit / auth errors by class name BEFORE the
+            # heuristic, because litellm rate-limit messages contain "tokens"
+            # + "limit" which would false-positive as context overflow.
+            exc_name = type(e).__name__
+            if exc_name in ("RateLimitError", "AuthenticationError", "NotFoundError"):
+                return LLMResponse(content=f"Error: {message}", error=message, error_code="provider_error")
             if is_context_limit_error(e):
                 raise LLMProviderError(message, code="context_limit") from e
             return LLMResponse(content=f"Error: {message}", error=message, error_code="provider_error")

--- a/plugins/services/service_llm.py
+++ b/plugins/services/service_llm.py
@@ -471,6 +471,166 @@ class LMStudioLLM(BaseLLM):
 
 
 # =====================================================================
+# LITELLM (Unified AI gateway — 100+ providers)
+#
+# Routes through litellm.completion() which normalizes all providers
+# (OpenAI, Anthropic, Google, AWS Bedrock, Azure, Groq, Mistral, etc.)
+# into a single OpenAI-compatible interface.
+# =====================================================================
+
+
+class LiteLLMLLM(BaseLLM):
+    """LLM backed by the LiteLLM SDK, routing to any of 100+ providers."""
+
+    def __init__(self, model_name, api_key=None, base_url=None):
+        super().__init__()
+        self.model_name = model_name
+        self.api_key = api_key
+        self.base_url = base_url
+        self.loaded = False
+        m = (model_name or "").lower()
+        if any(s in m for s in ("gpt-4o", "gpt-4.1", "gpt-5", "claude-3", "claude-4", "gemini")):
+            self.capabilities["image"] = True
+
+    def _load(self):
+        try:
+            import litellm
+            self.loaded = True
+            return True
+        except ImportError:
+            logger.error("litellm is not installed. Install with: pip install 'litellm>=1.60,<1.85'")
+            return False
+
+    def unload(self):
+        self.loaded = False
+        logger.info("LiteLLM model unloaded.")
+
+    def invoke(self, messages, attachments=None, **kwargs):
+        if not self.loaded:
+            return LLMResponse(content="Error: model not loaded", error="model not loaded", error_code="not_loaded")
+
+        try:
+            import litellm
+
+            messages, native_paths = self._resolve_attachments(messages, attachments)
+            messages = self._inject_images(messages, native_paths)
+
+            has_tools = "tools" in kwargs and kwargs["tools"]
+            logger.debug(f"LiteLLM invoke: {len(messages)} messages, tools={'yes' if has_tools else 'no'}, model={self.model_name}")
+
+            completion_kwargs = {
+                "model": self.model_name,
+                "messages": messages,
+                "drop_params": True,
+                **kwargs,
+            }
+            if self.api_key:
+                completion_kwargs["api_key"] = self.api_key
+            if self.base_url:
+                completion_kwargs["api_base"] = self.base_url
+
+            t0 = time.time()
+            response = litellm.completion(**completion_kwargs)
+            logger.debug(f"LiteLLM responded in {time.time() - t0:.2f}s")
+
+            choice = response.choices[0]
+            usage = getattr(response, "usage", None)
+            prompt_tok = getattr(usage, "prompt_tokens", None) if usage else None
+            cached_tok = _cached_prompt_tokens(usage)
+
+            if choice.message.tool_calls:
+                return LLMResponse(
+                    content=choice.message.content or "",
+                    tool_calls=[
+                        {"id": tc.id, "name": tc.function.name, "arguments": tc.function.arguments}
+                        for tc in choice.message.tool_calls
+                    ],
+                    prompt_tokens=prompt_tok,
+                    cached_prompt_tokens=cached_tok,
+                )
+
+            return LLMResponse(content=choice.message.content or "", prompt_tokens=prompt_tok, cached_prompt_tokens=cached_tok)
+
+        except Exception as e:
+            message = extract_llm_error_text(e)
+            logger.error(f"LiteLLM Invoke Error: {message}")
+            if is_context_limit_error(e):
+                raise LLMProviderError(message, code="context_limit") from e
+            return LLMResponse(content=f"Error: {message}", error=message, error_code="provider_error")
+
+    def stream(self, messages, attachments=None, **kwargs):
+        if not self.loaded:
+            return
+
+        try:
+            import litellm
+
+            messages, native_paths = self._resolve_attachments(messages, attachments)
+            messages = self._inject_images(messages, native_paths)
+
+            completion_kwargs = {
+                "model": self.model_name,
+                "messages": messages,
+                "stream": True,
+                "drop_params": True,
+                **kwargs,
+            }
+            if self.api_key:
+                completion_kwargs["api_key"] = self.api_key
+            if self.base_url:
+                completion_kwargs["api_base"] = self.base_url
+
+            response = litellm.completion(**completion_kwargs)
+            for chunk in response:
+                delta = chunk.choices[0].delta
+                if hasattr(delta, "content") and delta.content:
+                    yield delta.content
+        except Exception as e:
+            logger.error(f"LiteLLM Stream Error: {e}")
+
+    def chat_with_tools(self, messages, tools=None, **kwargs):
+        if tools:
+            kwargs["tools"] = tools
+        return self.invoke(messages, **kwargs)
+
+    def _inject_images(self, messages: list[dict], image_paths: list[str]) -> list[dict]:
+        """Inject base64 images into the last user message (reuses OpenAILLM pattern)."""
+        import base64
+
+        if not image_paths:
+            return messages
+
+        image_blocks = []
+        valid_names = []
+        for path in image_paths:
+            if not os.path.exists(path):
+                continue
+            image_bytes = self.get_image_bytes(path)
+            if not image_bytes:
+                continue
+            try:
+                b64 = base64.b64encode(image_bytes).decode("utf-8")
+                image_blocks.append({"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{b64}"}})
+                valid_names.append(Path(path).name)
+            except Exception as e:
+                logger.error(f"Failed to encode image {path}: {e}")
+
+        if not image_blocks:
+            return messages
+
+        messages = [msg.copy() for msg in messages]
+        for i in range(len(messages) - 1, -1, -1):
+            if messages[i]["role"] == "user":
+                original_content = messages[i]["content"]
+                img_ref = "\n".join(f"<Image {j+1}: {n}>" for j, n in enumerate(valid_names))
+                text = f"{original_content}\n\nThe following images are provided:\n{img_ref}"
+                messages[i]["content"] = [{"type": "text", "text": text}, *image_blocks]
+                break
+
+        return messages
+
+
+# =====================================================================
 # OPENAI-COMPATIBLE (OpenAI, LM Studio via endpoint, Ollama, vLLM, etc.)
 #
 # Uses the OpenAI Python SDK. Lightweight — no model lifecycle management.
@@ -685,6 +845,16 @@ def _build_llm_from_profile(model_name: str, profile: dict) -> BaseLLM:
 
     if cls_name == "LMStudioLLM":
         return LMStudioLLM(model_name)
+
+    if cls_name == "LiteLLMLLM":
+        api_key = profile.get("llm_api_key", "")
+        resolved_key = os.environ.get(api_key, api_key) if api_key else None
+        base_url = profile.get("llm_endpoint", "") or None
+        llm = LiteLLMLLM(model_name, api_key=resolved_key, base_url=base_url)
+        ctx = int(profile.get("llm_context_size", 0))
+        if ctx > 0:
+            llm.context_size = ctx
+        return llm
 
     api_key = profile.get("llm_api_key", "")
     resolved_key = os.environ.get(api_key, api_key) if api_key else None

--- a/plugins/services/service_llm.py
+++ b/plugins/services/service_llm.py
@@ -479,7 +479,7 @@ class LMStudioLLM(BaseLLM):
 # =====================================================================
 
 
-class LiteLLMLLM(BaseLLM):
+class LiteLLM(BaseLLM):
     """LLM backed by the LiteLLM SDK, routing to any of 100+ providers."""
 
     def __init__(self, model_name, api_key=None, base_url=None):
@@ -852,11 +852,11 @@ def _build_llm_from_profile(model_name: str, profile: dict) -> BaseLLM:
     if cls_name == "LMStudioLLM":
         return LMStudioLLM(model_name)
 
-    if cls_name == "LiteLLMLLM":
+    if cls_name == "LiteLLM":
         api_key = profile.get("llm_api_key", "")
         resolved_key = os.environ.get(api_key, api_key) if api_key else None
         base_url = profile.get("llm_endpoint", "") or None
-        llm = LiteLLMLLM(model_name, api_key=resolved_key, base_url=base_url)
+        llm = LiteLLM(model_name, api_key=resolved_key, base_url=base_url)
         ctx = int(profile.get("llm_context_size", 0))
         if ctx > 0:
             llm.context_size = ctx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # LLM / AI services
 openai
 lmstudio
+litellm>=1.60,<1.85
 
 # Embeddings
 sentence-transformers

--- a/tests/test_litellm_llm.py
+++ b/tests/test_litellm_llm.py
@@ -3,7 +3,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from plugins.services.service_llm import LiteLLMLLM, LLMResponse, _build_llm_from_profile
+from plugins.services.service_llm import LiteLLMLLM, LLMResponse, LLMProviderError, _build_llm_from_profile
 
 
 def _make_response(content="Hello!", tool_calls=None, prompt_tokens=10, completion_tokens=5):
@@ -114,6 +114,70 @@ class TestLiteLLMLLM(unittest.TestCase):
         llm.loaded = True
         result = llm.invoke([{"role": "user", "content": "test"}])
         self.assertEqual(result.content, "")
+
+    @patch("litellm.completion")
+    def test_rate_limit_not_misclassified_as_context_limit(self, mock_completion):
+        import litellm as _litellm
+        mock_completion.side_effect = _litellm.RateLimitError(
+            message="Rate limit exceeded. Quota request exceeds the tokens limit.",
+            llm_provider="anthropic",
+            model="anthropic/claude-sonnet-4-6",
+        )
+        llm = LiteLLMLLM("anthropic/claude-sonnet-4-6")
+        llm.loaded = True
+        result = llm.invoke([{"role": "user", "content": "test"}])
+        self.assertTrue(result.is_error)
+        self.assertEqual(result.error_code, "provider_error")
+        self.assertNotEqual(result.error_code, "context_limit")
+
+    @patch("litellm.completion")
+    def test_context_limit_raises_provider_error(self, mock_completion):
+        import litellm as _litellm
+        mock_completion.side_effect = _litellm.ContextWindowExceededError(
+            message="This model's maximum context length is 8192 tokens",
+            llm_provider="openai",
+            model="openai/gpt-4o",
+        )
+        llm = LiteLLMLLM("openai/gpt-4o")
+        llm.loaded = True
+        with self.assertRaises(LLMProviderError) as ctx:
+            llm.invoke([{"role": "user", "content": "test"}])
+        self.assertEqual(ctx.exception.code, "context_limit")
+
+    @patch("litellm.completion", return_value=_make_response())
+    def test_response_format_passthrough(self, mock_completion):
+        llm = LiteLLMLLM("openai/gpt-4o")
+        llm.loaded = True
+        llm.invoke(
+            [{"role": "user", "content": "test"}],
+            response_format={"type": "json_object"},
+        )
+        kw = mock_completion.call_args.kwargs
+        self.assertEqual(kw["response_format"], {"type": "json_object"})
+
+    @patch("litellm.completion", return_value=_make_response())
+    def test_chat_with_tools_passes_attachments(self, mock_completion):
+        llm = LiteLLMLLM("openai/gpt-4o")
+        llm.loaded = True
+        result = llm.chat_with_tools(
+            [{"role": "user", "content": "test"}],
+            tools=None,
+            attachments=None,
+        )
+        self.assertEqual(result.content, "Hello!")
+
+    def test_stream_not_loaded_returns_nothing(self):
+        llm = LiteLLMLLM("openai/gpt-4o")
+        chunks = list(llm.stream([{"role": "user", "content": "test"}]))
+        self.assertEqual(chunks, [])
+
+    def test_image_capability_inferred(self):
+        llm = LiteLLMLLM("anthropic/claude-sonnet-4-6")
+        self.assertFalse(llm.has_capability("image"))
+        llm2 = LiteLLMLLM("openai/gpt-4o")
+        self.assertTrue(llm2.has_capability("image"))
+        llm3 = LiteLLMLLM("anthropic/claude-3-5-sonnet")
+        self.assertTrue(llm3.has_capability("image"))
 
 
 if __name__ == "__main__":

--- a/tests/test_litellm_llm.py
+++ b/tests/test_litellm_llm.py
@@ -1,9 +1,9 @@
-"""Tests for LiteLLMLLM service plugin."""
+"""Tests for LiteLLM service plugin."""
 
 import unittest
 from unittest.mock import MagicMock, patch
 
-from plugins.services.service_llm import LiteLLMLLM, LLMResponse, LLMProviderError, _build_llm_from_profile
+from plugins.services.service_llm import LiteLLM, LLMResponse, LLMProviderError, _build_llm_from_profile
 
 
 def _make_response(content="Hello!", tool_calls=None, prompt_tokens=10, completion_tokens=5):
@@ -20,10 +20,10 @@ def _make_response(content="Hello!", tool_calls=None, prompt_tokens=10, completi
     return resp
 
 
-class TestLiteLLMLLM(unittest.TestCase):
+class TestLiteLLM(unittest.TestCase):
     @patch("litellm.completion", return_value=_make_response())
     def test_invoke_dispatches_to_litellm(self, mock_completion):
-        llm = LiteLLMLLM("anthropic/claude-sonnet-4-6")
+        llm = LiteLLM("anthropic/claude-sonnet-4-6")
         llm.loaded = True
         result = llm.invoke([{"role": "user", "content": "Hi"}])
         mock_completion.assert_called_once()
@@ -35,7 +35,7 @@ class TestLiteLLMLLM(unittest.TestCase):
 
     @patch("litellm.completion", return_value=_make_response())
     def test_invoke_forwards_api_key(self, mock_completion):
-        llm = LiteLLMLLM("openai/gpt-4o", api_key="sk-test")
+        llm = LiteLLM("openai/gpt-4o", api_key="sk-test")
         llm.loaded = True
         llm.invoke([{"role": "user", "content": "test"}])
         kw = mock_completion.call_args.kwargs
@@ -43,7 +43,7 @@ class TestLiteLLMLLM(unittest.TestCase):
 
     @patch("litellm.completion", return_value=_make_response())
     def test_invoke_forwards_base_url(self, mock_completion):
-        llm = LiteLLMLLM("openai/gpt-4o", base_url="http://localhost:4000")
+        llm = LiteLLM("openai/gpt-4o", base_url="http://localhost:4000")
         llm.loaded = True
         llm.invoke([{"role": "user", "content": "test"}])
         kw = mock_completion.call_args.kwargs
@@ -51,7 +51,7 @@ class TestLiteLLMLLM(unittest.TestCase):
 
     @patch("litellm.completion", return_value=_make_response())
     def test_invoke_returns_prompt_tokens(self, mock_completion):
-        llm = LiteLLMLLM("openai/gpt-4o")
+        llm = LiteLLM("openai/gpt-4o")
         llm.loaded = True
         result = llm.invoke([{"role": "user", "content": "test"}])
         self.assertEqual(result.prompt_tokens, 10)
@@ -63,7 +63,7 @@ class TestLiteLLMLLM(unittest.TestCase):
         tc.function.name = "get_weather"
         tc.function.arguments = '{"city": "London"}'
         mock_completion.return_value = _make_response(content="", tool_calls=[tc])
-        llm = LiteLLMLLM("openai/gpt-4o")
+        llm = LiteLLM("openai/gpt-4o")
         llm.loaded = True
         result = llm.invoke([{"role": "user", "content": "weather?"}], tools=[{"type": "function"}])
         self.assertTrue(result.has_tool_calls)
@@ -79,7 +79,7 @@ class TestLiteLLMLLM(unittest.TestCase):
         chunk2.choices[0].delta.content = " world"
         mock_completion.return_value = iter([chunk1, chunk2])
 
-        llm = LiteLLMLLM("openai/gpt-4o")
+        llm = LiteLLM("openai/gpt-4o")
         llm.loaded = True
         chunks = list(llm.stream([{"role": "user", "content": "test"}]))
         self.assertEqual(chunks, ["Hello", " world"])
@@ -87,21 +87,21 @@ class TestLiteLLMLLM(unittest.TestCase):
         self.assertTrue(kw["stream"])
 
     def test_invoke_not_loaded_returns_error(self):
-        llm = LiteLLMLLM("openai/gpt-4o")
+        llm = LiteLLM("openai/gpt-4o")
         result = llm.invoke([{"role": "user", "content": "test"}])
         self.assertTrue(result.is_error)
         self.assertEqual(result.error_code, "not_loaded")
 
     def test_build_llm_from_profile_litellm(self):
-        profile = {"llm_service_class": "LiteLLMLLM", "llm_api_key": "sk-test", "llm_context_size": 128000}
+        profile = {"llm_service_class": "LiteLLM", "llm_api_key": "sk-test", "llm_context_size": 128000}
         llm = _build_llm_from_profile("anthropic/claude-sonnet-4-6", profile)
-        self.assertIsInstance(llm, LiteLLMLLM)
+        self.assertIsInstance(llm, LiteLLM)
         self.assertEqual(llm.model_name, "anthropic/claude-sonnet-4-6")
         self.assertEqual(llm.context_size, 128000)
 
     @patch("litellm.completion", return_value=_make_response())
     def test_chat_with_tools_delegates_to_invoke(self, mock_completion):
-        llm = LiteLLMLLM("openai/gpt-4o")
+        llm = LiteLLM("openai/gpt-4o")
         llm.loaded = True
         tools = [{"type": "function", "function": {"name": "test"}}]
         llm.chat_with_tools([{"role": "user", "content": "test"}], tools=tools)
@@ -110,7 +110,7 @@ class TestLiteLLMLLM(unittest.TestCase):
 
     @patch("litellm.completion", return_value=_make_response(content=None))
     def test_null_content_returns_empty(self, mock_completion):
-        llm = LiteLLMLLM("openai/gpt-4o")
+        llm = LiteLLM("openai/gpt-4o")
         llm.loaded = True
         result = llm.invoke([{"role": "user", "content": "test"}])
         self.assertEqual(result.content, "")
@@ -123,7 +123,7 @@ class TestLiteLLMLLM(unittest.TestCase):
             llm_provider="anthropic",
             model="anthropic/claude-sonnet-4-6",
         )
-        llm = LiteLLMLLM("anthropic/claude-sonnet-4-6")
+        llm = LiteLLM("anthropic/claude-sonnet-4-6")
         llm.loaded = True
         result = llm.invoke([{"role": "user", "content": "test"}])
         self.assertTrue(result.is_error)
@@ -138,7 +138,7 @@ class TestLiteLLMLLM(unittest.TestCase):
             llm_provider="openai",
             model="openai/gpt-4o",
         )
-        llm = LiteLLMLLM("openai/gpt-4o")
+        llm = LiteLLM("openai/gpt-4o")
         llm.loaded = True
         with self.assertRaises(LLMProviderError) as ctx:
             llm.invoke([{"role": "user", "content": "test"}])
@@ -146,7 +146,7 @@ class TestLiteLLMLLM(unittest.TestCase):
 
     @patch("litellm.completion", return_value=_make_response())
     def test_response_format_passthrough(self, mock_completion):
-        llm = LiteLLMLLM("openai/gpt-4o")
+        llm = LiteLLM("openai/gpt-4o")
         llm.loaded = True
         llm.invoke(
             [{"role": "user", "content": "test"}],
@@ -157,7 +157,7 @@ class TestLiteLLMLLM(unittest.TestCase):
 
     @patch("litellm.completion", return_value=_make_response())
     def test_chat_with_tools_passes_attachments(self, mock_completion):
-        llm = LiteLLMLLM("openai/gpt-4o")
+        llm = LiteLLM("openai/gpt-4o")
         llm.loaded = True
         result = llm.chat_with_tools(
             [{"role": "user", "content": "test"}],
@@ -167,16 +167,16 @@ class TestLiteLLMLLM(unittest.TestCase):
         self.assertEqual(result.content, "Hello!")
 
     def test_stream_not_loaded_returns_nothing(self):
-        llm = LiteLLMLLM("openai/gpt-4o")
+        llm = LiteLLM("openai/gpt-4o")
         chunks = list(llm.stream([{"role": "user", "content": "test"}]))
         self.assertEqual(chunks, [])
 
     def test_image_capability_inferred(self):
-        llm = LiteLLMLLM("anthropic/claude-sonnet-4-6")
+        llm = LiteLLM("anthropic/claude-sonnet-4-6")
         self.assertFalse(llm.has_capability("image"))
-        llm2 = LiteLLMLLM("openai/gpt-4o")
+        llm2 = LiteLLM("openai/gpt-4o")
         self.assertTrue(llm2.has_capability("image"))
-        llm3 = LiteLLMLLM("anthropic/claude-3-5-sonnet")
+        llm3 = LiteLLM("anthropic/claude-3-5-sonnet")
         self.assertTrue(llm3.has_capability("image"))
 
 

--- a/tests/test_litellm_llm.py
+++ b/tests/test_litellm_llm.py
@@ -1,0 +1,120 @@
+"""Tests for LiteLLMLLM service plugin."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from plugins.services.service_llm import LiteLLMLLM, LLMResponse, _build_llm_from_profile
+
+
+def _make_response(content="Hello!", tool_calls=None, prompt_tokens=10, completion_tokens=5):
+    resp = MagicMock()
+    resp.choices = [MagicMock()]
+    resp.choices[0].message.content = content
+    resp.choices[0].message.tool_calls = tool_calls
+    resp.choices[0].finish_reason = "stop"
+    resp.usage = MagicMock()
+    resp.usage.prompt_tokens = prompt_tokens
+    resp.usage.completion_tokens = completion_tokens
+    resp.usage.total_tokens = prompt_tokens + completion_tokens
+    resp.usage.prompt_tokens_details = None
+    return resp
+
+
+class TestLiteLLMLLM(unittest.TestCase):
+    @patch("litellm.completion", return_value=_make_response())
+    def test_invoke_dispatches_to_litellm(self, mock_completion):
+        llm = LiteLLMLLM("anthropic/claude-sonnet-4-6")
+        llm.loaded = True
+        result = llm.invoke([{"role": "user", "content": "Hi"}])
+        mock_completion.assert_called_once()
+        kw = mock_completion.call_args.kwargs
+        self.assertEqual(kw["model"], "anthropic/claude-sonnet-4-6")
+        self.assertTrue(kw["drop_params"])
+        self.assertEqual(result.content, "Hello!")
+        self.assertIsNone(result.error)
+
+    @patch("litellm.completion", return_value=_make_response())
+    def test_invoke_forwards_api_key(self, mock_completion):
+        llm = LiteLLMLLM("openai/gpt-4o", api_key="sk-test")
+        llm.loaded = True
+        llm.invoke([{"role": "user", "content": "test"}])
+        kw = mock_completion.call_args.kwargs
+        self.assertEqual(kw["api_key"], "sk-test")
+
+    @patch("litellm.completion", return_value=_make_response())
+    def test_invoke_forwards_base_url(self, mock_completion):
+        llm = LiteLLMLLM("openai/gpt-4o", base_url="http://localhost:4000")
+        llm.loaded = True
+        llm.invoke([{"role": "user", "content": "test"}])
+        kw = mock_completion.call_args.kwargs
+        self.assertEqual(kw["api_base"], "http://localhost:4000")
+
+    @patch("litellm.completion", return_value=_make_response())
+    def test_invoke_returns_prompt_tokens(self, mock_completion):
+        llm = LiteLLMLLM("openai/gpt-4o")
+        llm.loaded = True
+        result = llm.invoke([{"role": "user", "content": "test"}])
+        self.assertEqual(result.prompt_tokens, 10)
+
+    @patch("litellm.completion")
+    def test_invoke_tool_calls(self, mock_completion):
+        tc = MagicMock()
+        tc.id = "call_123"
+        tc.function.name = "get_weather"
+        tc.function.arguments = '{"city": "London"}'
+        mock_completion.return_value = _make_response(content="", tool_calls=[tc])
+        llm = LiteLLMLLM("openai/gpt-4o")
+        llm.loaded = True
+        result = llm.invoke([{"role": "user", "content": "weather?"}], tools=[{"type": "function"}])
+        self.assertTrue(result.has_tool_calls)
+        self.assertEqual(result.tool_calls[0]["name"], "get_weather")
+
+    @patch("litellm.completion", return_value=_make_response())
+    def test_stream_yields_chunks(self, mock_completion):
+        chunk1 = MagicMock()
+        chunk1.choices = [MagicMock()]
+        chunk1.choices[0].delta.content = "Hello"
+        chunk2 = MagicMock()
+        chunk2.choices = [MagicMock()]
+        chunk2.choices[0].delta.content = " world"
+        mock_completion.return_value = iter([chunk1, chunk2])
+
+        llm = LiteLLMLLM("openai/gpt-4o")
+        llm.loaded = True
+        chunks = list(llm.stream([{"role": "user", "content": "test"}]))
+        self.assertEqual(chunks, ["Hello", " world"])
+        kw = mock_completion.call_args.kwargs
+        self.assertTrue(kw["stream"])
+
+    def test_invoke_not_loaded_returns_error(self):
+        llm = LiteLLMLLM("openai/gpt-4o")
+        result = llm.invoke([{"role": "user", "content": "test"}])
+        self.assertTrue(result.is_error)
+        self.assertEqual(result.error_code, "not_loaded")
+
+    def test_build_llm_from_profile_litellm(self):
+        profile = {"llm_service_class": "LiteLLMLLM", "llm_api_key": "sk-test", "llm_context_size": 128000}
+        llm = _build_llm_from_profile("anthropic/claude-sonnet-4-6", profile)
+        self.assertIsInstance(llm, LiteLLMLLM)
+        self.assertEqual(llm.model_name, "anthropic/claude-sonnet-4-6")
+        self.assertEqual(llm.context_size, 128000)
+
+    @patch("litellm.completion", return_value=_make_response())
+    def test_chat_with_tools_delegates_to_invoke(self, mock_completion):
+        llm = LiteLLMLLM("openai/gpt-4o")
+        llm.loaded = True
+        tools = [{"type": "function", "function": {"name": "test"}}]
+        llm.chat_with_tools([{"role": "user", "content": "test"}], tools=tools)
+        kw = mock_completion.call_args.kwargs
+        self.assertEqual(kw["tools"], tools)
+
+    @patch("litellm.completion", return_value=_make_response(content=None))
+    def test_null_content_returns_empty(self, mock_completion):
+        llm = LiteLLMLLM("openai/gpt-4o")
+        llm.loaded = True
+        result = llm.invoke([{"role": "user", "content": "test"}])
+        self.assertEqual(result.content, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `LiteLLM` as a third LLM backend alongside `OpenAILLM` and `LMStudioLLM`, enabling access to 100+ LLM providers (OpenAI, Anthropic, Google, AWS Bedrock, Azure, Groq, Mistral, Cohere, etc.) through the [LiteLLM](https://github.com/BerriAI/litellm) SDK.


## Changes

| File | What |
|------|------|
| `plugins/services/service_llm.py` | New `LiteLLM(BaseLLM)` class (~150 LOC): `invoke()`, `stream()`, `chat_with_tools()` with lazy litellm import, `drop_params=True`, image injection, tool call parsing, token usage tracking. Rate limit / auth errors checked by class name before `is_context_limit_error()` heuristic to prevent false positives. Updated `_build_llm_from_profile()` factory to handle `"LiteLLM"` class name. |
| `requirements.txt` | Added `litellm>=1.60,<1.85` |
| `tests/test_litellm_llm.py` | 16 unit tests |

## Usage

Add a LiteLLM profile in your config:

```json
{
  "llm_profiles": {
    "anthropic/claude-sonnet-4-6": {
      "llm_service_class": "LiteLLM",
      "llm_api_key": "ANTHROPIC_API_KEY",
      "llm_context_size": 200000
    },
    "openai/gpt-4o": {
      "llm_service_class": "LiteLLM",
      "llm_api_key": "OPENAI_API_KEY",
      "llm_context_size": 128000
    }
  },
  "default_llm_profile": "anthropic/claude-sonnet-4-6"
}
```

LiteLLM reads provider-specific env vars automatically (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.) or you can pass `llm_api_key` in the profile config.

Direct usage:

```python
from plugins.services.service_llm import LiteLLM

llm = LiteLLM("anthropic/claude-sonnet-4-6")
llm.load()

result = llm.invoke([{"role": "user", "content": "What is 2+2?"}])
print(result.content)  # "4"

for chunk in llm.stream([{"role": "user", "content": "Say hello"}]):
    print(chunk, end="")
```

Any model string LiteLLM supports works:

```
anthropic/claude-sonnet-4-6
openai/gpt-4o
vertex_ai/gemini-2.5-flash
bedrock/anthropic.claude-sonnet-4-6-v2:0
groq/llama-4-scout-17b-16e-instruct
mistral/mistral-large-latest
```

## Integration bug caught during deep-dive and fixed

`is_context_limit_error()` uses a heuristic that matches "tokens" + "limit" in error text. LiteLLM's rate limit messages (e.g., "Rate limit exceeded. Quota request exceeds the tokens limit.") contain both words, causing rate limits to be misclassified as context overflow. This would trigger the compact-and-retry path in `conversation_loop.py` instead of surfacing the actual error.

Fix: check exception class name (`RateLimitError`, `AuthenticationError`, `NotFoundError`) before the heuristic, so these deterministic errors short-circuit to `provider_error` instead of triggering context compaction.

## Tests

### Unit tests: 16/16 pass

```
$ python -m pytest tests/test_litellm_llm.py -v
tests/test_litellm_llm.py::test_build_llm_from_profile_litellm PASSED
tests/test_litellm_llm.py::test_chat_with_tools_delegates_to_invoke PASSED
tests/test_litellm_llm.py::test_chat_with_tools_passes_attachments PASSED
tests/test_litellm_llm.py::test_context_limit_raises_provider_error PASSED
tests/test_litellm_llm.py::test_image_capability_inferred PASSED
tests/test_litellm_llm.py::test_invoke_dispatches_to_litellm PASSED
tests/test_litellm_llm.py::test_invoke_forwards_api_key PASSED
tests/test_litellm_llm.py::test_invoke_forwards_base_url PASSED
tests/test_litellm_llm.py::test_invoke_not_loaded_returns_error PASSED
tests/test_litellm_llm.py::test_invoke_returns_prompt_tokens PASSED
tests/test_litellm_llm.py::test_invoke_tool_calls PASSED
tests/test_litellm_llm.py::test_null_content_returns_empty PASSED
tests/test_litellm_llm.py::test_rate_limit_not_misclassified_as_context_limit PASSED
tests/test_litellm_llm.py::test_response_format_passthrough PASSED
tests/test_litellm_llm.py::test_stream_not_loaded_returns_nothing PASSED
tests/test_litellm_llm.py::test_stream_yields_chunks PASSED
========================= 16 passed in 1.04s =========================
```

### Live E2E: Anthropic Claude Sonnet 4-6

```
=== Test 1: invoke ===
Content: 4
Tokens: 20
Error: None

=== Test 2: stream ===
Stream: Hello|!

PASS
```

## Risk / Compatibility

- Additive only. `OpenAILLM` and `LMStudioLLM` untouched.
- `LiteLLM` follows the same `BaseLLM` interface: `invoke()`, `stream()`, `chat_with_tools()` all return the same `LLMResponse` type.
- `litellm` is a new dependency in `requirements.txt`. Users who don't use it can ignore it.
- The `_build_llm_from_profile()` factory dispatches on `"LiteLLM"` class name, so existing profiles are unaffected.
